### PR TITLE
Fix shaders on iOS

### DIFF
--- a/src/imgui-quick/imguiitem.cpp
+++ b/src/imgui-quick/imguiitem.cpp
@@ -105,7 +105,7 @@ static const char *fragSrcES2 =
         "varying highp vec2 uv;\n"
         "varying highp vec4 color;\n"
         "void main() {\n"
-        "    vec4 c = color * texture2D(tex, uv);\n"
+        "    highp vec4 c = color * texture2D(tex, uv);\n"
         "    gl_FragColor = vec4(c.rgb, c.a * opacity);\n"
         "}\n";
 
@@ -131,7 +131,7 @@ static const char *fragSrcGL3 =
         "in vec4 color;\n"
         "out vec4 fragColor;\n"
         "void main() {\n"
-        "    vec4 c = color * texture(tex, uv);\n"
+        "    highp vec4 c = color * texture(tex, uv);\n"
         "    fragColor = vec4(c.rgb, c.a * opacity);\n"
         "}\n";
 


### PR DESCRIPTION
```
QOpenGLShader::compile(Fragment): ERROR: 0:7: 'vec4' : declaration must include a precision qualifier for type
ERROR: 0:8: Use of undeclared identifier 'c'
ERROR: 0:8: Use of undeclared identifier 'c'

2020-03-26T18:27:56 (default.warning): *** Problematic Fragment shader source code ***
#ifdef GL_KHR_blend_equation_advanced
#extension GL_ARB_fragment_coord_conventions : enable
#extension GL_KHR_blend_equation_advanced : enable
#endif
#ifndef GL_FRAGMENT_PRECISION_HIGH
#define highp mediump
#endif
#line 1
uniform sampler2D tex;
uniform lowp float opacity;
varying highp vec2 uv;
varying highp vec4 color;
void main() {
    vec4 c = color * texture2D(tex, uv);
    gl_FragColor = vec4(c.rgb, c.a * opacity);
}

***
```